### PR TITLE
Adds the concept of a publisher

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["src"]
+ :deps {cheshire/cheshire {:mvn/version "5.8.0"}           ;; json serialization
+        com.cognitect/transit-clj {:mvn/version "0.8.300"} ;; transit serialization
+        crypto-random/crypto-random {:mvn/version "1.2.0"} ;; job ids
+        org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/tools.logging {:mvn/version "0.4.0"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {}}}}

--- a/src/clj_faktory/core.clj
+++ b/src/clj_faktory/core.clj
@@ -1,7 +1,10 @@
 (ns clj-faktory.core
-  (:require [clj-faktory.worker :as worker]))
+  (:require [clj-faktory.publisher :as publisher]
+            [clj-faktory.worker :as worker]))
 
 (def perform-async worker/perform-async)
+(def publish       publisher/publish)
+(def publisher     publisher/publisher)
 (def worker        worker/worker)
 (def start         worker/start)
 (def stop          worker/stop)

--- a/src/clj_faktory/publisher.clj
+++ b/src/clj_faktory/publisher.clj
@@ -1,0 +1,27 @@
+(ns clj-faktory.publisher
+  (:require [clj-faktory.client :as client]
+            [clj-faktory.utils :as utils]
+            [crypto.random :as random]))
+
+(defn publish
+  ([publisher job-type args opts]
+   (let [jid (random/hex 12)
+         job (cond-> (merge {:jid jid
+                             :jobtype job-type
+                             :args args
+                             :queue "default"
+                             :retry 25
+                             :backtrace 10}
+                            opts)
+               (utils/transit-args? args) (utils/encode-transit-args))]
+     (client/push (::conn publisher) job)
+     jid))
+  ([publisher job-type args]
+   (publish publisher job-type args {})))
+
+(defn publisher [uri]
+  (let [info (utils/client-info)
+        conn (.connect (client/connection uri info))]
+    {::info info
+     ::opts {:uri uri}
+     ::conn conn}))

--- a/src/clj_faktory/utils.clj
+++ b/src/clj_faktory/utils.clj
@@ -1,0 +1,27 @@
+(ns clj-faktory.utils
+  (:require [cheshire.core :as cheshire]
+            [clj-faktory.protocol.transit :as transit]
+            [clojure.java.shell :as shell]
+            [clojure.string :as string]
+            [crypto.random :as random])
+  (:import [java.net InetAddress]))
+
+(defn encode-transit-args [job]
+  (-> job
+      (update :args (comp vector transit/write))
+      (assoc-in [:custom :args-encoding] "transit")))
+
+(defn transit-args? [args]
+  (not= args (cheshire/parse-string (cheshire/generate-string args))))
+
+(defn hostname []
+  (or (try (.getHostName (InetAddress/getLocalHost))
+           (catch Exception _))
+      (some-> (shell/sh "hostname")
+              (:out)
+              (string/trim))))
+
+(defn client-info []
+  {:wid (random/hex 12)
+   :hostname (hostname)
+   :v 2})


### PR DESCRIPTION
Some applications will only publish events to faktory. Using the worker model is not ideal in these cases.

This change adds a publisher that can only be used to publish events. The connection is not managed and will timeout if not used frequently enough. It will automatically reconnect if the socket was closed.

It looks like there could be a threading issue with publishing events concurrently, since they will use the same socket instance without anything preventing concurrent access. An application could pool publishers to deal with this or use a new connection every time.

From this page:
https://github.com/contribsys/faktory/blob/main/docs/protocol-specification.md

`Clients that are not consumers MUST NOT send BEAT commands, and MUST NOT enter the Quiet or Terminating stages.`